### PR TITLE
Fix access control condition contract type

### DIFF
--- a/src/encryption/lit/common.ts
+++ b/src/encryption/lit/common.ts
@@ -129,7 +129,7 @@ const generateTokenAccessControlCondition = (
       return {
         conditionType: "evmBasic",
         contractAddress: rule.contractAddress,
-        standardContractType: rule.type,
+        standardContractType: rule.contractType,
         chain: rule.chain,
         method: "balanceOf",
         parameters: [":userAddress", rule.tokenId],
@@ -143,7 +143,7 @@ const generateTokenAccessControlCondition = (
       return {
         conditionType: "evmBasic",
         contractAddress: rule.contractAddress,
-        standardContractType: rule.type,
+        standardContractType: rule.contractType,
         chain: rule.chain,
         method: "balanceOf",
         parameters: [":userAddress"],
@@ -200,3 +200,4 @@ export const parseOrbisRules = (
 
   return accessControlConditions;
 };
+


### PR DESCRIPTION
This pull request fixes an issue where the contract type was incorrectly set in the access control condition. The `rule.type` variable was being used instead of the correct variable `rule.contractType`. This caused incorrect behavior in the access control condition. This PR updates the code to use the correct variable and ensures that the contract type is set correctly.
